### PR TITLE
Defer script execution

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,10 +7,10 @@
             var cell = $("#t")[0].rows[row].cells[col];
             cell.style.backgroundColor = color;
              }
-             setColor(2,1, "purple");
+             $(function() { setColor(2,1, "purple") });
         </script>
         <link href="style.css" rel="stylesheet">
-        <script src="script.js"></script>
+        <script defer src="script.js"></script>
         <title>JS-Function-Grid</title>
     </head>
     <body>


### PR DESCRIPTION
The `setColor` function won’t work until the DOM is ready, since it’s selecting a cell from the table. Ensure that we aren’t calling it before DOMReady by:
- Using the `defer` attribute on the tag that loads `script.js`. This tells the browser not to execute the script until the DOM is ready, and is the preferred way of handling this class of problems
- Using a jQuery DOM ready handler to wrap the call to `setColor` in the inline script. Inline script tags can’t use `defer` so we have to do it old-school.
